### PR TITLE
Make datasette-pretty-json show Chinese characters by default.

### DIFF
--- a/datasette_pretty_json/__init__.py
+++ b/datasette_pretty_json/__init__.py
@@ -19,6 +19,6 @@ def render_cell(value):
         return None
     return Markup(
         '<pre style="white-space: pre-wrap">{data}</pre>'.format(
-            data=escape(json.dumps(data, indent=4))
+            data=escape(json.dumps(data, indent=4, ensure_ascii=False))
         )
     )


### PR DESCRIPTION
I was getting escaped Chinese character sequences (e.g. \u4f60\u597d instead of 你好). 

Adding `ensure_ascii=False` to the json dump to fix this.

Tested & confirmed. I just edited the 

`/opt/homebrew/lib/python3.11/site-packages/datasette_pretty_json/__init__.py` file. 

Very simple change. Easy to upstream. Thank you!